### PR TITLE
Postal driver - subscribe to '#' instead of '*' to allow for periods in topics

### DIFF
--- a/lib/io/postal/postal-driver.js
+++ b/lib/io/postal/postal-driver.js
@@ -60,7 +60,7 @@ module.exports = function(options) {
     assert(options.bus.name === 'postal');
     _.each(_options.bus.topics, function(topic) {
       var channel = postal.channel(topic.name);
-      var subscription = channel.subscribe('*', _options.bus.callback);
+      var subscription = channel.subscribe('#', _options.bus.callback);
       _channels.push({topic: topic, channel: channel});
       _subscriptions.push({topic: topic, subscription: subscription});
     });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postal": "~0.8.9",
     "axon": "~1.0.0",
     "prozess": "~0.6.4",
-    "kafkaesque": "0.0.6"
+    "kafkaesque": "pelger/kafkaesque"
   },
   "main": "lib/microbial",
   "repository": {


### PR DESCRIPTION
Fixes #1.

See https://github.com/postaljs/postal.js/blob/f4787f506b996a1f9b926bab222aa129795ea537/example/standard/js/main.js#L15-L29
